### PR TITLE
improved task inputs

### DIFF
--- a/src/main/kotlin/com/specificlanguages/MpsPlugin.kt
+++ b/src/main/kotlin/com/specificlanguages/MpsPlugin.kt
@@ -169,7 +169,7 @@ open class MpsPlugin @Inject constructor(
                     mpsConfiguration, buildModel, distLocation, distResolveTask, setupTask)
 
             val antConfig = configurations.detachedConfiguration(
-                    dependencies.create("org.apache.ant:ant-junit:1.10.1"))
+                    dependencies.create("org.apache.ant:ant-junit:1.10.12"))
 
             val artifactsDir = File(project.projectDir, "build/artifacts")
 
@@ -178,6 +178,7 @@ open class MpsPlugin @Inject constructor(
                 group = "build"
                 description = "Assembles the MPS project."
                 script = "build.xml"
+                inputs.files(fileTree(projectDir).include("**/*.mps")).withPropertyName("models")
                 targets = listOf("generate", "assemble")
                 scriptArgs = listOf("-Dmps_home=$distLocation", "-Dversion=${project.version}")
                 scriptClasspath = antConfig
@@ -263,7 +264,9 @@ open class MpsPlugin @Inject constructor(
 
             mainClass.set("de.itemis.mps.gradle.generate.MainKt")
 
-            inputs.file(buildModel)
+            inputs.file(buildModel).withPropertyName("build-model")
+            inputs.files(fileTree(this.project.projectDir).include("**/*.msd", "**/*.mpl", "**/*.devkit"))
+                .withPropertyName("module-files")
             outputs.file("build.xml")
 
             // Needed to avoid "URI is not hierarchical" exceptions


### PR DESCRIPTION
Gradle sometimes claims that all tasks in the project are up-to-date while a rebuild would be required.

When modifying a model file (*.mps) only the assembleMps doesn't recognize a changed input and gradle considers it up-to-date.
Added an input files dependency to every *.mps file in the project directory.

The same applies for changes to a module file that doesn't cause a change in build model. While these changes are very rare they sometimes happen and could cause strange errors at runtime. In my case I was getting class not found exception because a jar was missing in the build.xml libraries of the generate task.

I also updated to latest ant-junit with mitigates a couple of vulnerabilities in ant. 