### PR TITLE
Add task dependency graph and full build tests

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "mps-gradle-plugin"

--- a/subprojects/mps-gradle-plugin/build.gradle.kts
+++ b/subprojects/mps-gradle-plugin/build.gradle.kts
@@ -31,4 +31,8 @@ gradlePlugin {
 
 tasks.test {
     useJUnitPlatform()
+    systemProperty(
+        "test.mps-platform-cache.cacheRoot",
+        rootProject.layout.buildDirectory.dir("mps-platform-cache").get().asFile.absolutePath
+    )
 }

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/.gitignore
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/migration.xml
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/migration.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MigrationProperties">
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.ExplicitJavaFacetSettings" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.SplitMPSCoreStub2" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.DataFlowStubsToRegularNodes" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.JavaModuleSettingsToFacet" value="executed" />
+    <entry key="project.baseline.version" value="211" />
+    <entry key="project.migrated.version" value="232" />
+  </component>
+</project>

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/misc.xml
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/misc.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownNavigator.ProfileManager" plain-text-search-scope="Project Files" />
+  <component name="MarkdownProjectSettings" wasCopied="true">
+    <PreviewSettings splitEditorLayout="SPLIT" splitEditorPreview="PREVIEW" useGrayscaleRendering="false" zoomFactor="1.0" maxImageWidth="0" showGitHubPageIfSynced="false" allowBrowsingInPreview="false" synchronizePreviewPosition="true" highlightPreviewType="NONE" highlightFadeOut="5" highlightOnTyping="true" synchronizeSourcePosition="true" verticallyAlignSourceAndPreviewSyncPosition="true" showSearchHighlightsInPreview="false" showSelectionInPreview="true" openRemoteLinks="true" replaceUnicodeEmoji="false" lastLayoutSetsDefault="false">
+      <PanelProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.panel" providerName="Default - Swing" />
+      </PanelProvider>
+    </PreviewSettings>
+    <ParserSettings gitHubSyntaxChange="false" emojiShortcuts="1" emojiImages="0">
+      <PegdownExtensions>
+        <option name="ABBREVIATIONS" value="false" />
+        <option name="ANCHORLINKS" value="true" />
+        <option name="ASIDE" value="false" />
+        <option name="ATXHEADERSPACE" value="true" />
+        <option name="AUTOLINKS" value="false" />
+        <option name="DEFINITIONS" value="false" />
+        <option name="DEFINITION_BREAK_DOUBLE_BLANK_LINE" value="false" />
+        <option name="FENCED_CODE_BLOCKS" value="true" />
+        <option name="FOOTNOTES" value="false" />
+        <option name="HARDWRAPS" value="false" />
+        <option name="HTML_DEEP_PARSER" value="false" />
+        <option name="INSERTED" value="false" />
+        <option name="QUOTES" value="false" />
+        <option name="RELAXEDHRULES" value="true" />
+        <option name="SMARTS" value="false" />
+        <option name="STRIKETHROUGH" value="true" />
+        <option name="SUBSCRIPT" value="false" />
+        <option name="SUPERSCRIPT" value="false" />
+        <option name="SUPPRESS_HTML_BLOCKS" value="false" />
+        <option name="SUPPRESS_INLINE_HTML" value="false" />
+        <option name="TABLES" value="true" />
+        <option name="TASKLISTITEMS" value="true" />
+        <option name="TOC" value="false" />
+        <option name="WIKILINKS" value="false" />
+      </PegdownExtensions>
+      <ParserOptions>
+        <option name="ADMONITION_EXT" value="false" />
+        <option name="ATTRIBUTES_EXT" value="false" />
+        <option name="COMMONMARK_LISTS" value="true" />
+        <option name="DUMMY" value="false" />
+        <option name="EMOJI_SHORTCUTS" value="true" />
+        <option name="ENUMERATED_REFERENCES_EXT" value="false" />
+        <option name="FLEXMARK_FRONT_MATTER" value="false" />
+        <option name="GFM_LOOSE_BLANK_LINE_AFTER_ITEM_PARA" value="false" />
+        <option name="GFM_TABLE_RENDERING" value="true" />
+        <option name="GITBOOK_URL_ENCODING" value="false" />
+        <option name="GITHUB_LISTS" value="false" />
+        <option name="GITHUB_WIKI_LINKS" value="false" />
+        <option name="GITLAB_EXT" value="false" />
+        <option name="GITLAB_MATH_EXT" value="false" />
+        <option name="GITLAB_MERMAID_EXT" value="false" />
+        <option name="HEADER_ID_NON_ASCII_TO_LOWERCASE" value="false" />
+        <option name="HEADER_ID_NO_DUPED_DASHES" value="false" />
+        <option name="JEKYLL_FRONT_MATTER" value="false" />
+        <option name="MACROS_EXT" value="false" />
+        <option name="NO_TEXT_ATTRIBUTES" value="false" />
+        <option name="PARSE_HTML_ANCHOR_ID" value="false" />
+        <option name="PLANTUML_FENCED_CODE" value="false" />
+        <option name="PUML_FENCED_CODE" value="false" />
+        <option name="SIM_TOC_BLANK_LINE_SPACER" value="true" />
+      </ParserOptions>
+    </ParserSettings>
+    <HtmlSettings headerTopEnabled="false" headerBottomEnabled="false" bodyTopEnabled="false" bodyBottomEnabled="false" embedUrlContent="false" addPageHeader="true" embedImages="false" embedHttpImages="false" imageUriSerials="false" addDocTypeHtml="true" noParaTags="false" plantUmlConversion="0" mathConversion="0">
+      <GeneratorProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.generator" providerName="Default Swing HTML Generator" />
+      </GeneratorProvider>
+      <headerTop />
+      <headerBottom />
+      <bodyTop />
+      <bodyBottom />
+    </HtmlSettings>
+    <CssSettings previewScheme="UI_SCHEME" cssUri="" isCssUriEnabled="false" isCssUriSerial="true" isCssTextEnabled="false" isDynamicPageWidth="true">
+      <StylesheetProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.css" providerName="Default Swing Stylesheet" />
+      </StylesheetProvider>
+      <ScriptProviders />
+      <cssText />
+      <cssUriHistory />
+    </CssSettings>
+    <AnnotatorSettings targetHasSpaces="true" linkCaseMismatch="true" wikiCaseMismatch="true" wikiLinkHasDashes="true" notUnderWikiHome="true" targetNotWikiPageExt="true" notUnderSourceWikiHome="true" targetNameHasAnchor="true" targetPathHasAnchor="true" wikiLinkHasSlash="true" wikiLinkHasSubdir="true" wikiLinkHasOnlyAnchor="true" linkTargetsWikiHasExt="true" linkTargetsWikiHasBadExt="true" notUnderSameRepo="true" targetNotUnderVcs="false" linkNeedsExt="true" linkHasBadExt="true" linkTargetNeedsExt="true" linkTargetHasBadExt="true" wikiLinkNotInWiki="true" imageTargetNotInRaw="true" repoRelativeAcrossVcsRoots="true" multipleWikiTargetsMatch="true" unresolvedLinkReference="true" linkIsIgnored="true" anchorIsIgnored="true" anchorIsUnresolved="true" anchorLineReferenceIsUnresolved="true" anchorLineReferenceFormat="true" anchorHasDuplicates="true" abbreviationDuplicates="true" abbreviationNotUsed="true" attributeIdDuplicateDefinition="true" attributeIdNotUsed="true" footnoteDuplicateDefinition="true" footnoteUnresolved="true" footnoteDuplicates="true" footnoteNotUsed="true" macroDuplicateDefinition="true" macroUnresolved="true" macroDuplicates="true" macroNotUsed="true" referenceDuplicateDefinition="true" referenceUnresolved="true" referenceDuplicates="true" referenceNotUsed="true" referenceUnresolvedNumericId="true" enumRefDuplicateDefinition="true" enumRefUnresolved="true" enumRefDuplicates="true" enumRefNotUsed="true" enumRefLinkUnresolved="true" enumRefLinkDuplicates="true" simTocUpdateNeeded="true" simTocTitleSpaceNeeded="true" />
+    <HtmlExportSettings updateOnSave="false" parentDir="" targetDir="" cssDir="css" scriptDir="js" plainHtml="false" imageDir="" copyLinkedImages="false" imageUniquifyType="0" targetPathType="2" targetExt="" useTargetExt="false" noCssNoScripts="false" useElementStyleAttribute="false" linkToExportedHtml="true" exportOnSettingsChange="true" regenerateOnProjectOpen="false" linkFormatType="HTTP_ABSOLUTE" />
+    <LinkMapSettings>
+      <textMaps />
+    </LinkMapSettings>
+  </component>
+</project>

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/modules.xml
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/modules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MPSProject">
+    <projectModules>
+      <modulePath path="$PROJECT_DIR$/languages/com.specificlanguages.json/com.specificlanguages.json.mpl" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.specificlanguages.json.build/com.specificlanguages.json.build.msd" folder="" />
+    </projectModules>
+  </component>
+</project>

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/vcs.xml
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/.mps/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/build.gradle.kts
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/build.gradle.kts
@@ -1,0 +1,26 @@
+import com.specificlanguages.mps.MainBuild
+
+plugins {
+    id("com.specificlanguages.mps")
+}
+
+repositories {
+    maven("https://artifacts.itemis.cloud/repository/maven-mps/")
+    mavenCentral()
+}
+
+dependencies {
+    mps("com.jetbrains:mps:2024.3.1")
+    jbr("com.jetbrains.jdk:jbr_jcef:17.0.6-b469.82")
+}
+
+group = "com.specificlanguages.mps-json"
+version = "1.0.0-test"
+
+mpsBuilds {
+    create<MainBuild>("main") {
+        buildSolutionDescriptor = file("solutions/com.specificlanguages.json.build/com.specificlanguages.json.build.msd")
+        buildFile = layout.projectDirectory.file("build.xml")
+        buildArtifactsDirectory = layout.buildDirectory.dir("artifacts/com.specificlanguages.json")
+    }
+}

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/com.specificlanguages.json.mpl
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/com.specificlanguages.json.mpl
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="com.specificlanguages.json" uuid="f3f42ddf-d692-4c29-90fb-7360196f01ab" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java" compile="mps" classes="mps" ext="yes">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
+    <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
+    <language slang="l:5dae8159-ab99-46bb-a40d-0cee30ee7018:jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <language slang="l:134c38d4-e3af-4d9e-b069-1c7df0a4005d:jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <language slang="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" version="0" />
+    <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="f3f42ddf-d692-4c29-90fb-7360196f01ab(com.specificlanguages.json)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/generator/templates/com.specificlanguages.json.generator.templates@generator.mps
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/generator/templates/com.specificlanguages.json.generator.templates@generator.mps
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b47b4601-0ccd-4b42-a2e7-080998f217ed(com.specificlanguages.json.generator.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="k9h7" ref="r:fd752404-89d3-4ffe-bc3a-7fb7a27c63b6(com.specificlanguages.json.structure)" />
+  </imports>
+  <registry>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="1P8oQ4NaXDD">
+    <property role="TrG5h" value="main" />
+  </node>
+</model>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.behavior.mps
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.behavior.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:0e3ed68a-e841-4ab1-bafa-60852d5e8891(com.specificlanguages.json.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.constraints.mps
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.constraints.mps
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:f99b1d30-a143-4faa-ac5a-d05e0d070ec8(com.specificlanguages.json.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="5dae8159-ab99-46bb-a40d-0cee30ee7018" name="jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <use id="ea3159bf-f48e-4720-bde2-86dba75f0d34" name="jetbrains.mps.lang.context.defs" version="0" />
+    <use id="e51810c5-7308-4642-bcb6-469e61b5dd18" name="jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <use id="134c38d4-e3af-4d9e-b069-1c7df0a4005d" name="jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <use id="b3551702-269c-4f05-ba61-58060cef4292" name="jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7" name="jetbrains.mps.lang.context" version="0" />
+    <use id="ad93155d-79b2-4759-b10c-55123e763903" name="jetbrains.mps.lang.messages" version="0" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.editor.mps
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.editor.mps
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:4984d1ec-a1c9-4ad1-8af7-b206011783d5(com.specificlanguages.json.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="k9h7" ref="r:fd752404-89d3-4ffe-bc3a-7fb7a27c63b6(com.specificlanguages.json.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
+        <child id="1140524464360" name="cellLayout" index="2czzBx" />
+      </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
+      <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
+        <property id="1186414551515" name="flag" index="VOm3f" />
+      </concept>
+      <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
+      <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+        <child id="1219418656006" name="styleItem" index="3F10Kt" />
+      </concept>
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="1P8oQ4NaXEq">
+    <ref role="1XX52x" to="k9h7:1P8oQ4NaXDS" resolve="JsonFile" />
+    <node concept="3EZMnI" id="1P8oQ4NaXEs" role="2wV5jI">
+      <node concept="3F0ifn" id="1P8oQ4NaXEz" role="3EZMnx">
+        <property role="3F0ifm" value="JSON File" />
+      </node>
+      <node concept="3F0A7n" id="1P8oQ4NaXED" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="1P8oQ4NaXEL" role="3EZMnx">
+        <property role="3F0ifm" value=".json" />
+        <node concept="11L4FC" id="1P8oQ4NaXEQ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="ljvvj" id="1P8oQ4NaXEY" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1P8oQ4NaXFf" role="3EZMnx">
+        <property role="3F0ifm" value="" />
+        <node concept="ljvvj" id="1P8oQ4NaXFC" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="1P8oQ4NaXFv" role="3EZMnx">
+        <ref role="1NtTu8" to="k9h7:1P8oQ4NaXDY" resolve="content" />
+        <node concept="ljvvj" id="1P8oQ4NaXFE" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="1P8oQ4NaXEv" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1P8oQ4NaYfF">
+    <ref role="1XX52x" to="k9h7:1P8oQ4NaYfe" resolve="JsonString" />
+    <node concept="3EZMnI" id="1P8oQ4NaYfH" role="2wV5jI">
+      <node concept="3F0ifn" id="1P8oQ4NaYfO" role="3EZMnx">
+        <property role="3F0ifm" value="&quot;" />
+        <node concept="11LMrY" id="1P8oQ4NaYg9" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0A7n" id="1P8oQ4NaYfW" role="3EZMnx">
+        <ref role="1NtTu8" to="k9h7:1P8oQ4NaYfU" resolve="value" />
+      </node>
+      <node concept="3F0ifn" id="1P8oQ4NaYg4" role="3EZMnx">
+        <property role="3F0ifm" value="&quot;" />
+        <node concept="11L4FC" id="1P8oQ4NaYgb" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="2iRfu4" id="1P8oQ4NaYfK" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1P8oQ4NaYgG">
+    <ref role="1XX52x" to="k9h7:1P8oQ4NaYgd" resolve="JsonArray" />
+    <node concept="3EZMnI" id="1P8oQ4NaYgL" role="2wV5jI">
+      <node concept="l2Vlx" id="1P8oQ4NaYgO" role="2iSdaV" />
+      <node concept="3F0ifn" id="1P8oQ4NaYgS" role="3EZMnx">
+        <property role="3F0ifm" value="[" />
+        <node concept="ljvvj" id="1P8oQ4NaYh1" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F2HdR" id="1P8oQ4NaYhb" role="3EZMnx">
+        <ref role="1NtTu8" to="k9h7:1P8oQ4NaYgg" resolve="items" />
+        <node concept="l2Vlx" id="1P8oQ4NaYhd" role="2czzBx" />
+        <node concept="pj6Ft" id="1P8oQ4NaYhk" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="ljvvj" id="1P8oQ4NaYhm" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="1P8oQ4NaYhp" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1P8oQ4NaYgX" role="3EZMnx">
+        <property role="3F0ifm" value="]" />
+        <node concept="ljvvj" id="1P8oQ4NaYh3" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="1P8oQ4NaYi2">
+    <ref role="1XX52x" to="k9h7:1P8oQ4NaYht" resolve="JsonNumber" />
+    <node concept="3F0A7n" id="1P8oQ4NaYi4" role="2wV5jI">
+      <ref role="1NtTu8" to="k9h7:1P8oQ4NaYhw" resolve="value" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1P8oQ4NaZcJ">
+    <ref role="1XX52x" to="k9h7:1P8oQ4NaZcg" resolve="JsonBoolean" />
+    <node concept="3F0A7n" id="1P8oQ4NaZcL" role="2wV5jI">
+      <ref role="1NtTu8" to="k9h7:1P8oQ4NaZch" resolve="value" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1P8oQ4NbA0S">
+    <ref role="1XX52x" to="k9h7:1P8oQ4NbA0r" resolve="JsonNull" />
+    <node concept="3F0ifn" id="1P8oQ4NbA0U" role="2wV5jI">
+      <property role="3F0ifm" value="null" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1P8oQ4NbAbH">
+    <ref role="1XX52x" to="k9h7:1P8oQ4NaXFJ" resolve="KeyValuePair" />
+    <node concept="3EZMnI" id="1P8oQ4NbAbJ" role="2wV5jI">
+      <node concept="3F0ifn" id="6UYVSPrHXMU" role="3EZMnx">
+        <property role="3F0ifm" value="&quot;" />
+        <node concept="11LMrY" id="6UYVSPrHXN0" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0A7n" id="1P8oQ4NbAbQ" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="6UYVSPrHXN9" role="3EZMnx">
+        <property role="3F0ifm" value="&quot;" />
+        <node concept="11L4FC" id="6UYVSPrHXNh" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="6UYVSPrHXNm" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1P8oQ4NbAbW" role="3EZMnx">
+        <property role="3F0ifm" value=":" />
+      </node>
+      <node concept="3F1sOY" id="1P8oQ4NbAc4" role="3EZMnx">
+        <ref role="1NtTu8" to="k9h7:1P8oQ4NaXFM" resolve="value" />
+      </node>
+      <node concept="l2Vlx" id="1P8oQ4NbAbM" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="6UYVSPrHTZz">
+    <ref role="1XX52x" to="k9h7:1P8oQ4NaXFG" resolve="JsonObject" />
+    <node concept="3EZMnI" id="6UYVSPrHTZ_" role="2wV5jI">
+      <node concept="3F0ifn" id="6UYVSPrHTZG" role="3EZMnx">
+        <property role="3F0ifm" value="{" />
+        <node concept="ljvvj" id="6UYVSPrHU01" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F2HdR" id="6UYVSPrHTZU" role="3EZMnx">
+        <ref role="1NtTu8" to="k9h7:1P8oQ4NaXFO" resolve="contents" />
+        <node concept="l2Vlx" id="6UYVSPrHTZW" role="2czzBx" />
+        <node concept="lj46D" id="6UYVSPrHU03" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="6UYVSPrHU05" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="ljvvj" id="6UYVSPrHU08" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="6UYVSPrHTZM" role="3EZMnx">
+        <property role="3F0ifm" value="}" />
+        <node concept="ljvvj" id="6UYVSPrHU0c" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="6UYVSPrHTZC" role="2iSdaV" />
+    </node>
+  </node>
+</model>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.structure.mps
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.structure.mps
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fd752404-89d3-4ffe-bc3a-7fb7a27c63b6(com.specificlanguages.json.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
+        <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
+      </concept>
+      <concept id="1082978499127" name="jetbrains.mps.lang.structure.structure.ConstrainedDataTypeDeclaration" flags="ng" index="Az7Fb">
+        <property id="1083066089218" name="constraint" index="FLfZY" />
+      </concept>
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ" />
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="1P8oQ4NaXDS">
+    <property role="EcuMT" value="2110045694544566904" />
+    <property role="TrG5h" value="JsonFile" />
+    <property role="19KtqR" value="true" />
+    <property role="34LRSv" value="JSON File" />
+    <property role="R4oN_" value="Json File" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="1P8oQ4NaXDT" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="1TJgyj" id="1P8oQ4NaXDY" role="1TKVEi">
+      <property role="IQ2ns" value="2110045694544566910" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="content" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="1P8oQ4NaXDX">
+    <property role="EcuMT" value="2110045694544566909" />
+    <property role="TrG5h" value="IJsonValue" />
+  </node>
+  <node concept="1TIwiD" id="1P8oQ4NaXFG">
+    <property role="EcuMT" value="2110045694544567020" />
+    <property role="TrG5h" value="JsonObject" />
+    <property role="34LRSv" value="{" />
+    <property role="R4oN_" value="JSON Object" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="1P8oQ4NaXFH" role="PzmwI">
+      <ref role="PrY4T" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+    <node concept="1TJgyj" id="1P8oQ4NaXFO" role="1TKVEi">
+      <property role="IQ2ns" value="2110045694544567028" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="contents" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="1P8oQ4NaXFJ" resolve="KeyValuePair" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1P8oQ4NaXFJ">
+    <property role="EcuMT" value="2110045694544567023" />
+    <property role="TrG5h" value="KeyValuePair" />
+    <property role="34LRSv" value="&quot;" />
+    <property role="R4oN_" value="key/value pair" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="1P8oQ4NaXFM" role="1TKVEi">
+      <property role="IQ2ns" value="2110045694544567026" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="value" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+    <node concept="PrWs8" id="1P8oQ4NaXFK" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1P8oQ4NaYfe">
+    <property role="EcuMT" value="2110045694544569294" />
+    <property role="TrG5h" value="JsonString" />
+    <property role="34LRSv" value="&quot;" />
+    <property role="R4oN_" value="JSON String" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="1P8oQ4NaYff" role="PzmwI">
+      <ref role="PrY4T" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+    <node concept="1TJgyi" id="1P8oQ4NaYfU" role="1TKVEl">
+      <property role="IQ2nx" value="2110045694544569338" />
+      <property role="TrG5h" value="value" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1P8oQ4NaYgd">
+    <property role="EcuMT" value="2110045694544569357" />
+    <property role="TrG5h" value="JsonArray" />
+    <property role="34LRSv" value="[" />
+    <property role="R4oN_" value="JSON Array" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="1P8oQ4NaYgg" role="1TKVEi">
+      <property role="IQ2ns" value="2110045694544569360" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="items" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+    <node concept="PrWs8" id="1P8oQ4NaYge" role="PzmwI">
+      <ref role="PrY4T" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1P8oQ4NaYht">
+    <property role="EcuMT" value="2110045694544569437" />
+    <property role="TrG5h" value="JsonNumber" />
+    <property role="R4oN_" value="JSON Number" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="1P8oQ4NaYhw" role="1TKVEl">
+      <property role="IQ2nx" value="2110045694544569440" />
+      <property role="TrG5h" value="value" />
+      <ref role="AX2Wp" node="1P8oQ4NaYhz" resolve="JsonNumberDatatype" />
+    </node>
+    <node concept="PrWs8" id="1P8oQ4NaYhu" role="PzmwI">
+      <ref role="PrY4T" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+  </node>
+  <node concept="Az7Fb" id="1P8oQ4NaYhz">
+    <property role="3F6X1D" value="2110045694544569443" />
+    <property role="TrG5h" value="JsonNumberDatatype" />
+    <property role="FLfZY" value="-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?" />
+  </node>
+  <node concept="1TIwiD" id="1P8oQ4NaZcg">
+    <property role="EcuMT" value="2110045694544573200" />
+    <property role="TrG5h" value="JsonBoolean" />
+    <property role="R4oN_" value="JSON Boolean" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="1P8oQ4NaZch" role="1TKVEl">
+      <property role="IQ2nx" value="2110045694544573201" />
+      <property role="TrG5h" value="value" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="PrWs8" id="1P8oQ4NaZcj" role="PzmwI">
+      <ref role="PrY4T" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1P8oQ4NbA0r">
+    <property role="EcuMT" value="2110045694544732187" />
+    <property role="TrG5h" value="JsonNull" />
+    <property role="34LRSv" value="null" />
+    <property role="R4oN_" value="JSON null" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="1P8oQ4NbA0s" role="PzmwI">
+      <ref role="PrY4T" node="1P8oQ4NaXDX" resolve="IJsonValue" />
+    </node>
+  </node>
+</model>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.textGen.mps
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.textGen.mps
@@ -1,0 +1,535 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:9f886d96-0ce3-485a-9a55-2e2be971036b(com.specificlanguages.json.textGen)">
+  <persistence version="9" />
+  <languages>
+    <use id="b83431fe-5c8f-40bc-8a36-65e25f4dd253" name="jetbrains.mps.lang.textGen" version="1" />
+    <devkit ref="fa73d85a-ac7f-447b-846c-fcdc41caa600(jetbrains.mps.devkit.aspect.textgen)" />
+  </languages>
+  <imports>
+    <import index="k9h7" ref="r:fd752404-89d3-4ffe-bc3a-7fb7a27c63b6(com.specificlanguages.json.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="b83431fe-5c8f-40bc-8a36-65e25f4dd253" name="jetbrains.mps.lang.textGen">
+      <concept id="8931911391946696733" name="jetbrains.mps.lang.textGen.structure.ExtensionDeclaration" flags="in" index="9MYSb" />
+      <concept id="1237305208784" name="jetbrains.mps.lang.textGen.structure.NewLineAppendPart" flags="ng" index="l8MVK" />
+      <concept id="1237305334312" name="jetbrains.mps.lang.textGen.structure.NodeAppendPart" flags="ng" index="l9hG8">
+        <child id="1237305790512" name="value" index="lb14g" />
+      </concept>
+      <concept id="1237305557638" name="jetbrains.mps.lang.textGen.structure.ConstantStringAppendPart" flags="ng" index="la8eA">
+        <property id="1237305576108" name="value" index="lacIc" />
+      </concept>
+      <concept id="1237306079178" name="jetbrains.mps.lang.textGen.structure.AppendOperation" flags="nn" index="lc7rE">
+        <child id="1237306115446" name="part" index="lcghm" />
+      </concept>
+      <concept id="4357423944233036906" name="jetbrains.mps.lang.textGen.structure.IndentPart" flags="ng" index="2BGw6n" />
+      <concept id="1233670071145" name="jetbrains.mps.lang.textGen.structure.ConceptTextGenDeclaration" flags="ig" index="WtQ9Q">
+        <reference id="1233670257997" name="conceptDeclaration" index="WuzLi" />
+        <child id="1233749296504" name="textGenBlock" index="11c4hB" />
+        <child id="7991274449437422201" name="extension" index="33IsuW" />
+      </concept>
+      <concept id="1233748055915" name="jetbrains.mps.lang.textGen.structure.NodeParameter" flags="nn" index="117lpO" />
+      <concept id="1233749247888" name="jetbrains.mps.lang.textGen.structure.GenerateTextDeclaration" flags="in" index="11bSqf" />
+      <concept id="1236188139846" name="jetbrains.mps.lang.textGen.structure.WithIndentOperation" flags="nn" index="3izx1p">
+        <child id="1236188238861" name="list" index="3izTki" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+    </language>
+  </registry>
+  <node concept="WtQ9Q" id="1P8oQ4NaXGl">
+    <ref role="WuzLi" to="k9h7:1P8oQ4NaXDS" resolve="JsonFile" />
+    <node concept="9MYSb" id="1P8oQ4NaXKU" role="33IsuW">
+      <node concept="3clFbS" id="1P8oQ4NaXKV" role="2VODD2">
+        <node concept="3clFbF" id="1P8oQ4NaXLl" role="3cqZAp">
+          <node concept="Xl_RD" id="1P8oQ4NaXLk" role="3clFbG">
+            <property role="Xl_RC" value="json" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="11bSqf" id="1P8oQ4NaXMo" role="11c4hB">
+      <node concept="3clFbS" id="1P8oQ4NaXMp" role="2VODD2">
+        <node concept="lc7rE" id="1P8oQ4NaXRo" role="3cqZAp">
+          <node concept="l9hG8" id="1P8oQ4NaXRG" role="lcghm">
+            <node concept="2OqwBi" id="1P8oQ4NaY1t" role="lb14g">
+              <node concept="117lpO" id="1P8oQ4NaXSy" role="2Oq$k0" />
+              <node concept="3TrEf2" id="1P8oQ4NaYah" role="2OqNvi">
+                <ref role="3Tt5mk" to="k9h7:1P8oQ4NaXDY" resolve="content" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="WtQ9Q" id="1P8oQ4Nb3YX">
+    <ref role="WuzLi" to="k9h7:1P8oQ4NaXFG" resolve="JsonObject" />
+    <node concept="11bSqf" id="1P8oQ4Nb3YY" role="11c4hB">
+      <node concept="3clFbS" id="1P8oQ4Nb3YZ" role="2VODD2">
+        <node concept="lc7rE" id="1P8oQ4Nb3Zg" role="3cqZAp">
+          <node concept="la8eA" id="1P8oQ4Nb3Z$" role="lcghm">
+            <property role="lacIc" value="{" />
+          </node>
+        </node>
+        <node concept="3izx1p" id="1P8oQ4Nb416" role="3cqZAp">
+          <node concept="3clFbS" id="1P8oQ4Nb418" role="3izTki">
+            <node concept="2Gpval" id="1P8oQ4Nb41t" role="3cqZAp">
+              <node concept="2GrKxI" id="1P8oQ4Nb41u" role="2Gsz3X">
+                <property role="TrG5h" value="pair" />
+              </node>
+              <node concept="2OqwBi" id="1P8oQ4Nb4b0" role="2GsD0m">
+                <node concept="117lpO" id="1P8oQ4Nb42a" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="1P8oQ4Nb4lG" role="2OqNvi">
+                  <ref role="3TtcxE" to="k9h7:1P8oQ4NaXFO" resolve="contents" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="1P8oQ4Nb41w" role="2LFqv$">
+                <node concept="lc7rE" id="1P8oQ4Nb4ou" role="3cqZAp">
+                  <node concept="l8MVK" id="1P8oQ4Nb4oM" role="lcghm" />
+                  <node concept="2BGw6n" id="1P8oQ4Nb4po" role="lcghm" />
+                  <node concept="l9hG8" id="1P8oQ4Nb4q0" role="lcghm">
+                    <node concept="2GrUjf" id="1P8oQ4Nb4qS" role="lb14g">
+                      <ref role="2Gs0qQ" node="1P8oQ4Nb41u" resolve="pair" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="1P8oQ4Nb4uv" role="3cqZAp">
+                  <node concept="3clFbS" id="1P8oQ4Nb4ux" role="3clFbx">
+                    <node concept="lc7rE" id="1P8oQ4Nb8SS" role="3cqZAp">
+                      <node concept="la8eA" id="1P8oQ4Nb8Te" role="lcghm">
+                        <property role="lacIc" value="," />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="1P8oQ4Nb4BS" role="3clFbw">
+                    <node concept="2OqwBi" id="1P8oQ4Nb6M$" role="3uHU7w">
+                      <node concept="2OqwBi" id="1P8oQ4Nb4ZT" role="2Oq$k0">
+                        <node concept="117lpO" id="1P8oQ4Nb4NF" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="1P8oQ4Nb5b3" role="2OqNvi">
+                          <ref role="3TtcxE" to="k9h7:1P8oQ4NaXFO" resolve="contents" />
+                        </node>
+                      </node>
+                      <node concept="1yVyf7" id="1P8oQ4Nb8Gc" role="2OqNvi" />
+                    </node>
+                    <node concept="2GrUjf" id="1P8oQ4Nb4v0" role="3uHU7B">
+                      <ref role="2Gs0qQ" node="1P8oQ4Nb41u" resolve="pair" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1P8oQ4Nb96M" role="3cqZAp">
+          <node concept="3clFbS" id="1P8oQ4Nb96O" role="3clFbx">
+            <node concept="lc7rE" id="1P8oQ4Nbd7x" role="3cqZAp">
+              <node concept="l8MVK" id="1P8oQ4Nbd7R" role="lcghm" />
+              <node concept="2BGw6n" id="1P8oQ4Nbdsz" role="lcghm" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1P8oQ4NbbdJ" role="3clFbw">
+            <node concept="2OqwBi" id="1P8oQ4Nb9ia" role="2Oq$k0">
+              <node concept="117lpO" id="1P8oQ4Nb99w" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="1P8oQ4Nb9sf" role="2OqNvi">
+                <ref role="3TtcxE" to="k9h7:1P8oQ4NaXFO" resolve="contents" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="1P8oQ4Nbd6u" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1P8oQ4Nbdl9" role="3cqZAp" />
+        <node concept="lc7rE" id="1P8oQ4Nb408" role="3cqZAp">
+          <node concept="la8eA" id="1P8oQ4Nb40w" role="lcghm">
+            <property role="lacIc" value="}" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="WtQ9Q" id="1P8oQ4NbkYw">
+    <ref role="WuzLi" to="k9h7:1P8oQ4NaYgd" resolve="JsonArray" />
+    <node concept="11bSqf" id="1P8oQ4NbkYx" role="11c4hB">
+      <node concept="3clFbS" id="1P8oQ4NbkYy" role="2VODD2">
+        <node concept="lc7rE" id="1P8oQ4NbkYN" role="3cqZAp">
+          <node concept="la8eA" id="1P8oQ4NbkYO" role="lcghm">
+            <property role="lacIc" value="[" />
+          </node>
+        </node>
+        <node concept="3izx1p" id="1P8oQ4NbkYP" role="3cqZAp">
+          <node concept="3clFbS" id="1P8oQ4NbkYQ" role="3izTki">
+            <node concept="2Gpval" id="1P8oQ4NbkYR" role="3cqZAp">
+              <node concept="2GrKxI" id="1P8oQ4NbkYS" role="2Gsz3X">
+                <property role="TrG5h" value="item" />
+              </node>
+              <node concept="2OqwBi" id="1P8oQ4NbkYT" role="2GsD0m">
+                <node concept="117lpO" id="1P8oQ4NbkYU" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="1P8oQ4Nbltu" role="2OqNvi">
+                  <ref role="3TtcxE" to="k9h7:1P8oQ4NaYgg" resolve="items" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="1P8oQ4NbkYW" role="2LFqv$">
+                <node concept="lc7rE" id="1P8oQ4NbkYX" role="3cqZAp">
+                  <node concept="l8MVK" id="1P8oQ4NbkYY" role="lcghm" />
+                  <node concept="2BGw6n" id="1P8oQ4NbkYZ" role="lcghm" />
+                  <node concept="l9hG8" id="1P8oQ4NbkZ0" role="lcghm">
+                    <node concept="2GrUjf" id="1P8oQ4NbkZ1" role="lb14g">
+                      <ref role="2Gs0qQ" node="1P8oQ4NbkYS" resolve="item" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="1P8oQ4NbkZ2" role="3cqZAp">
+                  <node concept="3clFbS" id="1P8oQ4NbkZ3" role="3clFbx">
+                    <node concept="lc7rE" id="1P8oQ4NbkZ4" role="3cqZAp">
+                      <node concept="la8eA" id="1P8oQ4NbkZ5" role="lcghm">
+                        <property role="lacIc" value="," />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="1P8oQ4NbkZ6" role="3clFbw">
+                    <node concept="2OqwBi" id="1P8oQ4NbkZ7" role="3uHU7w">
+                      <node concept="2OqwBi" id="1P8oQ4NbkZ8" role="2Oq$k0">
+                        <node concept="117lpO" id="1P8oQ4NbkZ9" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="1P8oQ4Nbm3m" role="2OqNvi">
+                          <ref role="3TtcxE" to="k9h7:1P8oQ4NaYgg" resolve="items" />
+                        </node>
+                      </node>
+                      <node concept="1yVyf7" id="1P8oQ4NbkZb" role="2OqNvi" />
+                    </node>
+                    <node concept="2GrUjf" id="1P8oQ4NbkZc" role="3uHU7B">
+                      <ref role="2Gs0qQ" node="1P8oQ4NbkYS" resolve="item" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1P8oQ4Nbmfb" role="3cqZAp" />
+        <node concept="3clFbJ" id="1P8oQ4NbkZd" role="3cqZAp">
+          <node concept="3clFbS" id="1P8oQ4NbkZe" role="3clFbx">
+            <node concept="lc7rE" id="1P8oQ4NbkZf" role="3cqZAp">
+              <node concept="l8MVK" id="1P8oQ4NbkZg" role="lcghm" />
+              <node concept="2BGw6n" id="1P8oQ4NbkZh" role="lcghm" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1P8oQ4NbkZi" role="3clFbw">
+            <node concept="2OqwBi" id="1P8oQ4NbkZj" role="2Oq$k0">
+              <node concept="117lpO" id="1P8oQ4NbkZk" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="1P8oQ4NbkZl" role="2OqNvi">
+                <ref role="3TtcxE" to="k9h7:1P8oQ4NaYgg" resolve="items" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="1P8oQ4NbkZm" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="lc7rE" id="1P8oQ4NbkZo" role="3cqZAp">
+          <node concept="la8eA" id="1P8oQ4NbkZp" role="lcghm">
+            <property role="lacIc" value="]" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="WtQ9Q" id="1P8oQ4Nbmmc">
+    <ref role="WuzLi" to="k9h7:1P8oQ4NaZcg" resolve="JsonBoolean" />
+    <node concept="11bSqf" id="1P8oQ4Nbmmd" role="11c4hB">
+      <node concept="3clFbS" id="1P8oQ4Nbmme" role="2VODD2">
+        <node concept="lc7rE" id="1P8oQ4Nbmmv" role="3cqZAp">
+          <node concept="l9hG8" id="1P8oQ4NbmmN" role="lcghm">
+            <node concept="2YIFZM" id="1P8oQ4Nbmof" role="lb14g">
+              <ref role="37wK5l" to="wyt6:~Boolean.toString(boolean)" resolve="toString" />
+              <ref role="1Pybhc" to="wyt6:~Boolean" resolve="Boolean" />
+              <node concept="2OqwBi" id="1P8oQ4NbmEd" role="37wK5m">
+                <node concept="117lpO" id="1P8oQ4Nbmt1" role="2Oq$k0" />
+                <node concept="3TrcHB" id="1P8oQ4NbmO$" role="2OqNvi">
+                  <ref role="3TsBF5" to="k9h7:1P8oQ4NaZch" resolve="value" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="WtQ9Q" id="1P8oQ4NbmRN">
+    <ref role="WuzLi" to="k9h7:1P8oQ4NaYht" resolve="JsonNumber" />
+    <node concept="11bSqf" id="1P8oQ4NbmRO" role="11c4hB">
+      <node concept="3clFbS" id="1P8oQ4NbmRP" role="2VODD2">
+        <node concept="lc7rE" id="1P8oQ4NbmS6" role="3cqZAp">
+          <node concept="l9hG8" id="1P8oQ4NbmSq" role="lcghm">
+            <node concept="2OqwBi" id="1P8oQ4Nbn2X" role="lb14g">
+              <node concept="117lpO" id="1P8oQ4NbmTg" role="2Oq$k0" />
+              <node concept="3TrcHB" id="1P8oQ4NbndL" role="2OqNvi">
+                <ref role="3TsBF5" to="k9h7:1P8oQ4NaYhw" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="WtQ9Q" id="1P8oQ4Nbnhh">
+    <ref role="WuzLi" to="k9h7:1P8oQ4NaYfe" resolve="JsonString" />
+    <node concept="11bSqf" id="1P8oQ4Nbnhi" role="11c4hB">
+      <node concept="3clFbS" id="1P8oQ4Nbnhj" role="2VODD2">
+        <node concept="lc7rE" id="1P8oQ4Nbnh$" role="3cqZAp">
+          <node concept="la8eA" id="1P8oQ4NbnhS" role="lcghm">
+            <property role="lacIc" value="&quot;" />
+          </node>
+          <node concept="l9hG8" id="1P8oQ4Nb_DH" role="lcghm">
+            <node concept="2YIFZM" id="1P8oQ4Nb_Fr" role="lb14g">
+              <ref role="37wK5l" node="1P8oQ4Nb$s0" resolve="escapeJson" />
+              <ref role="1Pybhc" node="1P8oQ4Nb$q_" resolve="Escaping" />
+              <node concept="2OqwBi" id="1P8oQ4Nb_Nc" role="37wK5m">
+                <node concept="117lpO" id="1P8oQ4Nb_G5" role="2Oq$k0" />
+                <node concept="3TrcHB" id="1P8oQ4Nb_Xy" role="2OqNvi">
+                  <ref role="3TsBF5" to="k9h7:1P8oQ4NaYfU" resolve="value" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="la8eA" id="1P8oQ4NbA5_" role="lcghm">
+            <property role="lacIc" value="&quot;" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="1P8oQ4Nb$q_">
+    <property role="TrG5h" value="Escaping" />
+    <node concept="2YIFZL" id="1P8oQ4Nb$s0" role="jymVt">
+      <property role="TrG5h" value="escapeJson" />
+      <node concept="3clFbS" id="1P8oQ4Nb$s3" role="3clF47">
+        <node concept="3cpWs6" id="1P8oQ4Nb_b8" role="3cqZAp">
+          <node concept="2OqwBi" id="1P8oQ4Nb_b9" role="3cqZAk">
+            <node concept="2OqwBi" id="1P8oQ4Nb_ba" role="2Oq$k0">
+              <node concept="2OqwBi" id="1P8oQ4Nb_bb" role="2Oq$k0">
+                <node concept="2OqwBi" id="1P8oQ4Nb_bc" role="2Oq$k0">
+                  <node concept="2OqwBi" id="1P8oQ4Nb_bd" role="2Oq$k0">
+                    <node concept="2OqwBi" id="1P8oQ4Nb_be" role="2Oq$k0">
+                      <node concept="2OqwBi" id="1P8oQ4Nb_bf" role="2Oq$k0">
+                        <node concept="37vLTw" id="1P8oQ4Nb_bg" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1P8oQ4Nb$sr" resolve="raw" />
+                        </node>
+                        <node concept="liA8E" id="1P8oQ4Nb_bh" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                          <node concept="Xl_RD" id="1P8oQ4Nb_bi" role="37wK5m">
+                            <property role="Xl_RC" value="\\" />
+                          </node>
+                          <node concept="Xl_RD" id="1P8oQ4Nb_bj" role="37wK5m">
+                            <property role="Xl_RC" value="\\\\" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="1P8oQ4Nb_bk" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                        <node concept="Xl_RD" id="1P8oQ4Nb_bl" role="37wK5m">
+                          <property role="Xl_RC" value="\&quot;" />
+                        </node>
+                        <node concept="Xl_RD" id="1P8oQ4Nb_bm" role="37wK5m">
+                          <property role="Xl_RC" value="\\\&quot;" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1P8oQ4Nb_bn" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                      <node concept="Xl_RD" id="1P8oQ4Nb_bo" role="37wK5m">
+                        <property role="Xl_RC" value="\b" />
+                      </node>
+                      <node concept="Xl_RD" id="1P8oQ4Nb_bp" role="37wK5m">
+                        <property role="Xl_RC" value="\\b" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="1P8oQ4Nb_bq" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                    <node concept="Xl_RD" id="1P8oQ4Nb_br" role="37wK5m">
+                      <property role="Xl_RC" value="\f" />
+                    </node>
+                    <node concept="Xl_RD" id="1P8oQ4Nb_bs" role="37wK5m">
+                      <property role="Xl_RC" value="\\f" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="1P8oQ4Nb_bt" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                  <node concept="Xl_RD" id="1P8oQ4Nb_bu" role="37wK5m">
+                    <property role="Xl_RC" value="\n" />
+                  </node>
+                  <node concept="Xl_RD" id="1P8oQ4Nb_bv" role="37wK5m">
+                    <property role="Xl_RC" value="\\n" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="1P8oQ4Nb_bw" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                <node concept="Xl_RD" id="1P8oQ4Nb_bx" role="37wK5m">
+                  <property role="Xl_RC" value="\r" />
+                </node>
+                <node concept="Xl_RD" id="1P8oQ4Nb_by" role="37wK5m">
+                  <property role="Xl_RC" value="\\r" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="1P8oQ4Nb_bz" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+              <node concept="Xl_RD" id="1P8oQ4Nb_b$" role="37wK5m">
+                <property role="Xl_RC" value="\t" />
+              </node>
+              <node concept="Xl_RD" id="1P8oQ4Nb_b_" role="37wK5m">
+                <property role="Xl_RC" value="\\t" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1P8oQ4Nb$rh" role="1B3o_S" />
+      <node concept="17QB3L" id="1P8oQ4Nb$rO" role="3clF45" />
+      <node concept="37vLTG" id="1P8oQ4Nb$sr" role="3clF46">
+        <property role="TrG5h" value="raw" />
+        <node concept="17QB3L" id="1P8oQ4Nb$sq" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1P8oQ4Nb$qA" role="1B3o_S" />
+  </node>
+  <node concept="WtQ9Q" id="1P8oQ4NbAcX">
+    <ref role="WuzLi" to="k9h7:1P8oQ4NaXFJ" resolve="KeyValuePair" />
+    <node concept="11bSqf" id="1P8oQ4NbAcY" role="11c4hB">
+      <node concept="3clFbS" id="1P8oQ4NbAcZ" role="2VODD2">
+        <node concept="lc7rE" id="1P8oQ4NbAdg" role="3cqZAp">
+          <node concept="la8eA" id="1P8oQ4NbAd$" role="lcghm">
+            <property role="lacIc" value="&quot;" />
+          </node>
+          <node concept="l9hG8" id="1P8oQ4NbAep" role="lcghm">
+            <node concept="2YIFZM" id="1P8oQ4NbAg8" role="lb14g">
+              <ref role="37wK5l" node="1P8oQ4Nb$s0" resolve="escapeJson" />
+              <ref role="1Pybhc" node="1P8oQ4Nb$q_" resolve="Escaping" />
+              <node concept="2OqwBi" id="1P8oQ4NbAnQ" role="37wK5m">
+                <node concept="117lpO" id="1P8oQ4NbAgJ" role="2Oq$k0" />
+                <node concept="3TrcHB" id="1P8oQ4NbAyc" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="la8eA" id="1P8oQ4NbA_V" role="lcghm">
+            <property role="lacIc" value="&quot;: " />
+          </node>
+          <node concept="l9hG8" id="1P8oQ4NbAEf" role="lcghm">
+            <node concept="2OqwBi" id="1P8oQ4NbAOL" role="lb14g">
+              <node concept="117lpO" id="1P8oQ4NbAFH" role="2Oq$k0" />
+              <node concept="3TrEf2" id="1P8oQ4NbAZp" role="2OqNvi">
+                <ref role="3Tt5mk" to="k9h7:1P8oQ4NaXFM" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="WtQ9Q" id="1P8oQ4NbB30">
+    <ref role="WuzLi" to="k9h7:1P8oQ4NbA0r" resolve="JsonNull" />
+    <node concept="11bSqf" id="1P8oQ4NbB31" role="11c4hB">
+      <node concept="3clFbS" id="1P8oQ4NbB32" role="2VODD2">
+        <node concept="lc7rE" id="1P8oQ4NbB3j" role="3cqZAp">
+          <node concept="la8eA" id="1P8oQ4NbB3B" role="lcghm">
+            <property role="lacIc" value="null" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.typesystem.mps
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/languages/com.specificlanguages.json/models/com.specificlanguages.json.typesystem.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:c7c972ab-b6cf-4661-b5c8-7978fc62f0d4(com.specificlanguages.json.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/settings.gradle.kts
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "mps-json"

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/solutions/com.specificlanguages.json.build/com.specificlanguages.json.build.msd
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/solutions/com.specificlanguages.json.build/com.specificlanguages.json.build.msd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="com.specificlanguages.json.build" uuid="84f0ad52-c7ca-45dd-99c5-9605c96bf808" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java" compile="mps" classes="mps" ext="no">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <dependencies>
+    <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
+    <language slang="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" version="7" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="84f0ad52-c7ca-45dd-99c5-9605c96bf808(com.specificlanguages.json.build)" version="0" />
+    <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/solutions/com.specificlanguages.json.build/models/com.specificlanguages.json.build.mps
+++ b/subprojects/mps-gradle-plugin/etc/test-projects/mps-json/solutions/com.specificlanguages.json.build/models/com.specificlanguages.json.build.mps
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:1044fb59-f691-4b27-8b09-aa9b966feb0e(com.specificlanguages.json.build)">
+  <persistence version="9" />
+  <languages>
+    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
+    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="7" />
+  </languages>
+  <imports>
+    <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
+  </imports>
+  <registry>
+    <language id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml">
+      <concept id="6666499814681415858" name="jetbrains.mps.core.xml.structure.XmlElement" flags="ng" index="2pNNFK">
+        <property id="6666499814681415862" name="tagName" index="2pNNFO" />
+        <child id="1622293396948928802" name="content" index="3o6s8t" />
+      </concept>
+      <concept id="1622293396948952339" name="jetbrains.mps.core.xml.structure.XmlText" flags="nn" index="3o6iSG">
+        <property id="1622293396948953704" name="value" index="3o6i5n" />
+      </concept>
+    </language>
+    <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
+      <concept id="5481553824944787378" name="jetbrains.mps.build.structure.BuildSourceProjectRelativePath" flags="ng" index="55IIr" />
+      <concept id="2755237150521975431" name="jetbrains.mps.build.structure.BuildVariableMacroInitWithString" flags="ng" index="aVJcg">
+        <child id="2755237150521975437" name="value" index="aVJcq" />
+      </concept>
+      <concept id="7321017245476976379" name="jetbrains.mps.build.structure.BuildRelativePath" flags="ng" index="iG8Mu">
+        <child id="7321017245477039051" name="compositePart" index="iGT6I" />
+      </concept>
+      <concept id="3767587139141066978" name="jetbrains.mps.build.structure.BuildVariableMacro" flags="ng" index="2kB4xC">
+        <child id="2755237150521975432" name="initialValue" index="aVJcv" />
+      </concept>
+      <concept id="4993211115183325728" name="jetbrains.mps.build.structure.BuildProjectDependency" flags="ng" index="2sgV4H">
+        <reference id="5617550519002745380" name="script" index="1l3spb" />
+        <child id="4129895186893471026" name="artifacts" index="2JcizS" />
+      </concept>
+      <concept id="4380385936562003279" name="jetbrains.mps.build.structure.BuildString" flags="ng" index="NbPM2">
+        <child id="4903714810883783243" name="parts" index="3MwsjC" />
+      </concept>
+      <concept id="8618885170173601777" name="jetbrains.mps.build.structure.BuildCompositePath" flags="nn" index="2Ry0Ak">
+        <property id="8618885170173601779" name="head" index="2Ry0Am" />
+        <child id="8618885170173601778" name="tail" index="2Ry0An" />
+      </concept>
+      <concept id="6647099934206700647" name="jetbrains.mps.build.structure.BuildJavaPlugin" flags="ng" index="10PD9b" />
+      <concept id="7389400916848136194" name="jetbrains.mps.build.structure.BuildFolderMacro" flags="ng" index="398rNT" />
+      <concept id="7389400916848153117" name="jetbrains.mps.build.structure.BuildSourceMacroRelativePath" flags="ng" index="398BVA">
+        <reference id="7389400916848153130" name="macro" index="398BVh" />
+      </concept>
+      <concept id="5617550519002745364" name="jetbrains.mps.build.structure.BuildLayout" flags="ng" index="1l3spV" />
+      <concept id="5617550519002745363" name="jetbrains.mps.build.structure.BuildProject" flags="ng" index="1l3spW">
+        <property id="5204048710541015587" name="internalBaseDirectory" index="2DA0ip" />
+        <child id="6647099934206700656" name="plugins" index="10PD9s" />
+        <child id="7389400916848080626" name="parts" index="3989C9" />
+        <child id="5617550519002745381" name="dependencies" index="1l3spa" />
+        <child id="5617550519002745378" name="macros" index="1l3spd" />
+        <child id="5617550519002745372" name="layout" index="1l3spN" />
+      </concept>
+      <concept id="8654221991637384182" name="jetbrains.mps.build.structure.BuildFileIncludesSelector" flags="ng" index="3qWCbU">
+        <property id="8654221991637384184" name="pattern" index="3qWCbO" />
+      </concept>
+      <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ngI" index="1y1bJS">
+        <child id="7389400916848037006" name="children" index="39821P" />
+      </concept>
+      <concept id="841011766566059607" name="jetbrains.mps.build.structure.BuildStringNotEmpty" flags="ng" index="3_J27D" />
+      <concept id="5248329904287794596" name="jetbrains.mps.build.structure.BuildInputFiles" flags="ng" index="3LXTmp">
+        <child id="5248329904287794598" name="dir" index="3LXTmr" />
+        <child id="5248329904287794679" name="selectors" index="3LXTna" />
+      </concept>
+      <concept id="4903714810883702019" name="jetbrains.mps.build.structure.BuildTextStringPart" flags="ng" index="3Mxwew">
+        <property id="4903714810883755350" name="text" index="3MwjfP" />
+      </concept>
+      <concept id="4903714810883702017" name="jetbrains.mps.build.structure.BuildVarRefStringPart" flags="ng" index="3Mxwey">
+        <reference id="4903714810883702018" name="macro" index="3Mxwex" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps">
+      <concept id="7832771629084799699" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginVendor" flags="ng" index="2iUeEo">
+        <property id="7832771629084799702" name="name" index="2iUeEt" />
+        <property id="7832771629084799701" name="url" index="2iUeEu" />
+      </concept>
+      <concept id="6592112598314586625" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginGroup" flags="ng" index="m$f5U">
+        <reference id="6592112598314586626" name="group" index="m$f5T" />
+      </concept>
+      <concept id="6592112598314498932" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPlugin" flags="ng" index="m$_wf">
+        <property id="6592112598314498927" name="id" index="m$_wk" />
+        <child id="1359186315025500371" name="xml" index="20twgj" />
+        <child id="7832771629084912518" name="vendor" index="2iVFfd" />
+        <child id="6592112598314498931" name="version" index="m$_w8" />
+        <child id="6592112598314499050" name="content" index="m$_yh" />
+        <child id="6592112598314499028" name="dependencies" index="m$_yJ" />
+        <child id="6592112598314499021" name="name" index="m$_yQ" />
+        <child id="6592112598314855574" name="containerName" index="m_cZH" />
+        <child id="2172791612906637490" name="description" index="3s6cr7" />
+      </concept>
+      <concept id="6592112598314498926" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_Plugin" flags="ng" index="m$_wl">
+        <reference id="6592112598314801433" name="plugin" index="m_rDy" />
+        <child id="3570488090019868128" name="packagingType" index="pUk7w" />
+      </concept>
+      <concept id="6592112598314499027" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginDependency" flags="ng" index="m$_yC">
+        <reference id="6592112598314499066" name="target" index="m$_y1" />
+      </concept>
+      <concept id="3570488090019868065" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_AutoPluginLayoutType" flags="ng" index="pUk6x" />
+      <concept id="1500819558095907805" name="jetbrains.mps.build.mps.structure.BuildMps_Group" flags="ng" index="2G$12M">
+        <child id="1500819558095907806" name="modules" index="2G$12L" />
+      </concept>
+      <concept id="868032131020265945" name="jetbrains.mps.build.mps.structure.BuildMPSPlugin" flags="ng" index="3b7kt6" />
+      <concept id="5253498789149381388" name="jetbrains.mps.build.mps.structure.BuildMps_Module" flags="ng" index="3bQrTs">
+        <child id="5253498789149547825" name="sources" index="3bR31x" />
+        <child id="5253498789149547704" name="dependencies" index="3bR37C" />
+      </concept>
+      <concept id="5253498789149585690" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyOnModule" flags="ng" index="3bR9La">
+        <reference id="5253498789149547705" name="module" index="3bR37D" />
+      </concept>
+      <concept id="763829979718664966" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleResources" flags="ng" index="3rtmxn">
+        <child id="763829979718664967" name="files" index="3rtmxm" />
+      </concept>
+      <concept id="4278635856200817744" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleModelRoot" flags="ng" index="1BupzO">
+        <property id="8137134783396907368" name="convert2binary" index="1Hdu6h" />
+        <property id="8137134783396676838" name="extracted" index="1HemKv" />
+        <property id="2889113830911481881" name="deployFolderName" index="3ZfqAx" />
+        <child id="8137134783396676835" name="location" index="1HemKq" />
+      </concept>
+      <concept id="3189788309731840247" name="jetbrains.mps.build.mps.structure.BuildMps_Solution" flags="ng" index="1E1JtA" />
+      <concept id="3189788309731840248" name="jetbrains.mps.build.mps.structure.BuildMps_Language" flags="ng" index="1E1JtD" />
+      <concept id="322010710375871467" name="jetbrains.mps.build.mps.structure.BuildMps_AbstractModule" flags="ng" index="3LEN3z">
+        <property id="8369506495128725901" name="compact" index="BnDLt" />
+        <property id="322010710375892619" name="uuid" index="3LESm3" />
+        <child id="322010710375956261" name="path" index="3LF7KH" />
+      </concept>
+      <concept id="7259033139236285166" name="jetbrains.mps.build.mps.structure.BuildMps_ExtractedModuleDependency" flags="nn" index="1SiIV0">
+        <child id="7259033139236285167" name="dependency" index="1SiIV1" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1l3spW" id="2Hp7a1emEW">
+    <property role="TrG5h" value="com.specificlanguages.json" />
+    <property role="2DA0ip" value="../.." />
+    <node concept="10PD9b" id="2Hp7a1emEX" role="10PD9s" />
+    <node concept="3b7kt6" id="2Hp7a1emEY" role="10PD9s" />
+    <node concept="398rNT" id="2Hp7a1emEZ" role="1l3spd">
+      <property role="TrG5h" value="mps_home" />
+    </node>
+    <node concept="2kB4xC" id="2Hp7a1emFQ" role="1l3spd">
+      <property role="TrG5h" value="version" />
+      <node concept="aVJcg" id="2Hp7a1emFW" role="aVJcv">
+        <node concept="NbPM2" id="2Hp7a1emFV" role="aVJcq">
+          <node concept="3Mxwew" id="2Hp7a1emFU" role="3MwsjC">
+            <property role="3MwjfP" value="SET_FROM_GRADLE" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2sgV4H" id="2Hp7a1emF0" role="1l3spa">
+      <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
+      <node concept="398BVA" id="2Hp7a1emF1" role="2JcizS">
+        <ref role="398BVh" node="2Hp7a1emEZ" resolve="mps_home" />
+      </node>
+    </node>
+    <node concept="1l3spV" id="2Hp7a1emFu" role="1l3spN">
+      <node concept="m$_wl" id="2Hp7a1emFy" role="39821P">
+        <ref role="m_rDy" node="2Hp7a1emFh" resolve="com.specificlanguages.json" />
+        <node concept="pUk6x" id="2Hp7a1emFz" role="pUk7w" />
+      </node>
+    </node>
+    <node concept="m$_wf" id="2Hp7a1emFh" role="3989C9">
+      <property role="m$_wk" value="com.specificlanguages.json" />
+      <node concept="3_J27D" id="2Hp7a1emFi" role="m$_yQ">
+        <node concept="3Mxwew" id="2Hp7a1emFj" role="3MwsjC">
+          <property role="3MwjfP" value="com.specificlanguages.json" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="2Hp7a1emFk" role="m$_w8">
+        <node concept="3Mxwey" id="2Hp7a1emG4" role="3MwsjC">
+          <ref role="3Mxwex" node="2Hp7a1emFQ" resolve="version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="2Hp7a1emFm" role="m$_yh">
+        <ref role="m$f5T" node="2Hp7a1emFg" resolve="mps-json" />
+      </node>
+      <node concept="m$_yC" id="2Hp7a1emFn" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="4d5TAmvMQCJ" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
+      </node>
+      <node concept="3_J27D" id="2Hp7a1emFo" role="m_cZH">
+        <node concept="3Mxwew" id="2Hp7a1emFp" role="3MwsjC">
+          <property role="3MwjfP" value="com.specificlanguages.json" />
+        </node>
+      </node>
+      <node concept="2pNNFK" id="2Hp7a1emFq" role="20twgj">
+        <property role="2pNNFO" value="depends" />
+        <node concept="3o6iSG" id="2Hp7a1emFr" role="3o6s8t">
+          <property role="3o6i5n" value="com.intellij.modules.platform" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="2Hp7a1emFF" role="3s6cr7">
+        <node concept="3Mxwew" id="2Hp7a1emFH" role="3MwsjC">
+          <property role="3MwjfP" value="JSON language implementation" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="2Hp7a1emG6" role="2iVFfd">
+        <property role="2iUeEt" value="Sergej Koščejev" />
+        <property role="2iUeEu" value="https://specificlanguages.com/" />
+      </node>
+    </node>
+    <node concept="2G$12M" id="2Hp7a1emFg" role="3989C9">
+      <property role="TrG5h" value="mps-json" />
+      <node concept="1E1JtD" id="2Hp7a1emFf" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.specificlanguages.json" />
+        <property role="3LESm3" value="f3f42ddf-d692-4c29-90fb-7360196f01ab" />
+        <node concept="55IIr" id="2Hp7a1emFa" role="3LF7KH">
+          <node concept="2Ry0Ak" id="2Hp7a1emFb" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2Hp7a1emFc" role="2Ry0An">
+              <property role="2Ry0Am" value="com.specificlanguages.json" />
+              <node concept="2Ry0Ak" id="2Hp7a1emFd" role="2Ry0An">
+                <property role="2Ry0Am" value="com.specificlanguages.json.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="2Hp7a1emFC" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2Hp7a1emFD" role="1HemKq">
+            <node concept="55IIr" id="2Hp7a1emF$" role="3LXTmr">
+              <node concept="2Ry0Ak" id="2Hp7a1emF_" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2Hp7a1emFA" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.specificlanguages.json" />
+                  <node concept="2Ry0Ak" id="2Hp7a1emFB" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2Hp7a1emFE" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="47WVKz8eLt_" role="3bR31x">
+          <node concept="3LXTmp" id="47WVKz8eLtA" role="3rtmxm">
+            <node concept="55IIr" id="47WVKz8eLtB" role="3LXTmr">
+              <node concept="2Ry0Ak" id="47WVKz8eLtC" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="47WVKz8eLtD" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.specificlanguages.json" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="47WVKz8eLtF" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2Hp7a1emGK" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.specificlanguages.json.build" />
+        <property role="3LESm3" value="84f0ad52-c7ca-45dd-99c5-9605c96bf808" />
+        <node concept="55IIr" id="2Hp7a1emGM" role="3LF7KH">
+          <node concept="2Ry0Ak" id="2Hp7a1emHl" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2Hp7a1emHq" role="2Ry0An">
+              <property role="2Ry0Am" value="com.specificlanguages.json.build" />
+              <node concept="2Ry0Ak" id="2Hp7a1emHv" role="2Ry0An">
+                <property role="2Ry0Am" value="com.specificlanguages.json.build.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2Hp7a1emH_" role="3bR37C">
+          <node concept="3bR9La" id="2Hp7a1emHA" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2Hp7a1emHF" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2Hp7a1emHG" role="1HemKq">
+            <node concept="55IIr" id="2Hp7a1emHB" role="3LXTmr">
+              <node concept="2Ry0Ak" id="2Hp7a1emHC" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2Hp7a1emHD" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.specificlanguages.json.build" />
+                  <node concept="2Ry0Ak" id="2Hp7a1emHE" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2Hp7a1emHH" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/subprojects/mps-gradle-plugin/src/test/kotlin/com/specificlanguages/mps/FullBuildTest.kt
+++ b/subprojects/mps-gradle-plugin/src/test/kotlin/com/specificlanguages/mps/FullBuildTest.kt
@@ -1,0 +1,66 @@
+package com.specificlanguages.mps
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.zip.ZipFile
+
+class FullBuildTest {
+
+    companion object {
+        private val TEST_PROJECT_DIR = File("etc/test-projects/mps-json")
+
+        /**
+         * The cache root shared with the outer Gradle build. The mps-platform-cache plugin in the test project
+         * will use this directory to avoid re-downloading MPS for every test run.
+         */
+        private val CACHE_ROOT = File(System.getProperty("test.mps-platform-cache.cacheRoot",
+            File("../../build/mps-platform-cache").absolutePath))
+    }
+
+    @Test
+    fun `full build produces ZIP with expected jars`(@TempDir workDir: File) {
+        TEST_PROJECT_DIR.copyRecursively(workDir)
+        writeGradleProperties(workDir)
+
+        val result = GradleRunner.create()
+            .withProjectDir(workDir)
+            .withPluginClasspath()
+            .withArguments("assemble")
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateBuildScripts")?.outcome,
+            "generateBuildScripts should succeed")
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateMain")?.outcome,
+            "generate task should succeed")
+        assertEquals(TaskOutcome.SUCCESS, result.task(":assembleMain")?.outcome,
+            "assemble task should succeed")
+        assertEquals(TaskOutcome.SUCCESS, result.task(":zip")?.outcome,
+            "zip task should succeed")
+
+        val zipFile = workDir.resolve("build/distributions/mps-json-1.0.0-test.zip")
+        assertThat("ZIP file should be produced", zipFile.exists(), `is`(true))
+
+        val jarNames = ZipFile(zipFile).use { zip ->
+            zip.entries().asSequence()
+                .map { it.name }
+                .filter { it.endsWith(".jar") }
+                .map { it.substringAfterLast("/") }
+                .toSet()
+        }
+
+        assertThat("ZIP should contain the language jar",
+            jarNames, hasItem(containsString("com.specificlanguages.json")))
+    }
+
+    private fun writeGradleProperties(projectDir: File) {
+        projectDir.resolve("gradle.properties").writeText(
+            "com.specificlanguages.mps-platform-cache.cacheRoot=${CACHE_ROOT.absolutePath}\n"
+        )
+    }
+}

--- a/subprojects/mps-gradle-plugin/src/test/kotlin/com/specificlanguages/mps/FullBuildTest.kt
+++ b/subprojects/mps-gradle-plugin/src/test/kotlin/com/specificlanguages/mps/FullBuildTest.kt
@@ -5,6 +5,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -18,9 +19,12 @@ class FullBuildTest {
         /**
          * The cache root shared with the outer Gradle build. The mps-platform-cache plugin in the test project
          * will use this directory to avoid re-downloading MPS for every test run.
+         *
+         * Must be set via the `test.mps-platform-cache.cacheRoot` system property in the build file.
          */
-        private val CACHE_ROOT = File(System.getProperty("test.mps-platform-cache.cacheRoot",
-            File("../../build/mps-platform-cache").absolutePath))
+        private val CACHE_ROOT = File(System.getProperty("test.mps-platform-cache.cacheRoot")
+            ?: error("System property 'test.mps-platform-cache.cacheRoot' is not set. " +
+                "Configure it in the build file via tasks.test { systemProperty(...) }."))
     }
 
     @Test
@@ -44,7 +48,7 @@ class FullBuildTest {
             "zip task should succeed")
 
         val zipFile = workDir.resolve("build/distributions/mps-json-1.0.0-test.zip")
-        assertThat("ZIP file should be produced", zipFile.exists(), `is`(true))
+        assertTrue(zipFile.exists(), "ZIP file should be produced at ${zipFile.path}")
 
         val jarNames = ZipFile(zipFile).use { zip ->
             zip.entries().asSequence()

--- a/subprojects/mps-gradle-plugin/src/test/kotlin/com/specificlanguages/mps/TaskDependencyGraphTest.kt
+++ b/subprojects/mps-gradle-plugin/src/test/kotlin/com/specificlanguages/mps/TaskDependencyGraphTest.kt
@@ -1,0 +1,173 @@
+package com.specificlanguages.mps
+
+import org.gradle.api.Task
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+@Suppress("UNCHECKED_CAST")
+class TaskDependencyGraphTest {
+
+    private lateinit var project: ProjectInternal
+
+    @BeforeEach
+    fun setUp(@TempDir tempDir: Path) {
+        project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build() as ProjectInternal
+        project.plugins.apply("com.specificlanguages.mps")
+
+        // Override mpsHome to a dummy directory so that the mps-platform-cache provider chain
+        // (which requires an mps dependency) is not triggered when resolving task dependencies.
+        val mpsDefaults = project.extensions.getByType(MpsDefaultsExtension::class.java)
+        mpsDefaults.mpsHome.set(tempDir.resolve("fake-mps").toFile())
+    }
+
+    private val mpsBuilds: org.gradle.api.PolymorphicDomainObjectContainer<MpsBuild>
+        get() = project.extensions.getByName("mpsBuilds")
+            as org.gradle.api.PolymorphicDomainObjectContainer<MpsBuild>
+
+    private val bundledDependencies: org.gradle.api.NamedDomainObjectContainer<BundledDependency>
+        get() = project.extensions.getByName("bundledDependencies")
+            as org.gradle.api.NamedDomainObjectContainer<BundledDependency>
+
+    @Test
+    fun `single MainBuild wires generate, assemble, zip, and assemble lifecycle`() {
+        mpsBuilds.create("main", MainBuild::class.java) {
+            buildSolutionDescriptor.set(project.file("foo.msd"))
+            buildArtifactsDirectory.set(project.layout.buildDirectory.dir("artifacts/main"))
+        }
+
+        project.evaluate()
+
+        assertTaskDependsOn("generateMain", "generateBuildScripts")
+        assertTaskDependsOn("assembleMain", "generateMain")
+        assertTaskDependsOn("zip", "assembleMain")
+        assertTaskDependsOn("assemble", "zip")
+    }
+
+    @Test
+    fun `single TestBuild wires generate, check, test, and check lifecycle`() {
+        mpsBuilds.create("myTest", TestBuild::class.java) {
+            buildSolutionDescriptor.set(project.file("foo.msd"))
+        }
+
+        project.evaluate()
+
+        assertTaskDependsOn("generateMyTest", "generateBuildScripts")
+        assertTaskDependsOn("checkMyTest", "generateMyTest")
+        assertTaskDependsOn("test", "checkMyTest")
+        assertTaskDependsOn("check", "test")
+    }
+
+    @Test
+    fun `MainBuild and TestBuild wire correctly together`() {
+        val main = mpsBuilds.create("main", MainBuild::class.java) {
+            buildSolutionDescriptor.set(project.file("foo.msd"))
+            buildArtifactsDirectory.set(project.layout.buildDirectory.dir("artifacts/main"))
+        }
+
+        mpsBuilds.create("tests", TestBuild::class.java) {
+            dependsOn(main)
+            buildSolutionDescriptor.set(project.file("bar.msd"))
+        }
+
+        project.evaluate()
+
+        // MainBuild wiring
+        assertTaskDependsOn("generateMain", "generateBuildScripts")
+        assertTaskDependsOn("assembleMain", "generateMain")
+        assertTaskDependsOn("zip", "assembleMain")
+        assertTaskDependsOn("assemble", "zip")
+
+        // TestBuild wiring
+        assertTaskDependsOn("generateTests", "generateBuildScripts")
+        assertTaskDependsOn("checkTests", "generateTests")
+        assertTaskDependsOn("test", "checkTests")
+        assertTaskDependsOn("check", "test")
+
+        // Cross-build dependency: TestBuild's generate depends on MainBuild's assemble
+        assertTaskDependsOn("generateTests", "assembleMain")
+    }
+
+    @Test
+    fun `multiple MainBuilds with dependsOn wire generate to assemble of dependency`() {
+        val buildA = mpsBuilds.create("buildA", MainBuild::class.java) {
+            buildSolutionDescriptor.set(project.file("a.msd"))
+            buildArtifactsDirectory.set(project.layout.buildDirectory.dir("artifacts/buildA"))
+        }
+
+        mpsBuilds.create("buildB", MainBuild::class.java) {
+            dependsOn(buildA)
+            buildSolutionDescriptor.set(project.file("b.msd"))
+            buildArtifactsDirectory.set(project.layout.buildDirectory.dir("artifacts/buildB"))
+        }
+
+        project.evaluate()
+
+        // Build A wiring
+        assertTaskDependsOn("generateBuildA", "generateBuildScripts")
+        assertTaskDependsOn("assembleBuildA", "generateBuildA")
+
+        // Build B wiring
+        assertTaskDependsOn("generateBuildB", "generateBuildScripts")
+        assertTaskDependsOn("assembleBuildB", "generateBuildB")
+
+        // Cross-build dependency: B's generate depends on A's assemble
+        assertTaskDependsOn("generateBuildB", "assembleBuildA")
+
+        // Both contribute to zip
+        assertTaskDependsOn("zip", "assembleBuildA")
+        assertTaskDependsOn("zip", "assembleBuildB")
+    }
+
+    @Test
+    fun `bundledDependencies resolve tasks wire before generateBuildScripts`() {
+        mpsBuilds.create("main", MainBuild::class.java) {
+            buildSolutionDescriptor.set(project.file("foo.msd"))
+            buildArtifactsDirectory.set(project.layout.buildDirectory.dir("artifacts/main"))
+        }
+
+        bundledDependencies.create("myLib") {
+            destinationDir.set(project.layout.projectDirectory.dir("libs"))
+        }
+
+        project.evaluate()
+
+        // The resolve task for the bundled dependency should be wired before generateBuildScripts
+        // via the setup task chain: resolveMyLib -> setup -> generateBuildScripts
+        assertTaskDependsOn("setup", "resolveMyLib")
+        assertTaskDependsOn("generateBuildScripts", "setup")
+    }
+
+    @Test
+    fun `unpublished MainBuild does not contribute to zip`() {
+        mpsBuilds.create("internal", MainBuild::class.java) {
+            published.set(false)
+            buildSolutionDescriptor.set(project.file("foo.msd"))
+            buildArtifactsDirectory.set(project.layout.buildDirectory.dir("artifacts/internal"))
+        }
+
+        project.evaluate()
+
+        // The zip task should still exist but not depend on assembleInternal
+        val zipDeps = taskDependencyNames("zip")
+        assertThat(zipDeps, not(hasItem("assembleInternal")))
+    }
+
+    private fun taskDependencyNames(taskName: String): Set<String> {
+        val task = project.tasks.getByName(taskName)
+        return task.taskDependencies.getDependencies(task).map(Task::getName).toSet()
+    }
+
+    private fun assertTaskDependsOn(taskName: String, dependencyName: String) {
+        assertThat(
+            "Task ':$taskName' should depend on ':$dependencyName'",
+            taskDependencyNames(taskName),
+            hasItem(dependencyName)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- **TaskDependencyGraphTest**: 6 fast ProjectBuilder-based tests verifying task wiring for single MainBuild, single TestBuild, MainBuild+TestBuild, multiple MainBuilds with dependsOn, bundledDependencies, and unpublished builds.
- **FullBuildTest**: End-to-end GradleRunner test building the mps-json project, asserting task success and expected jars in the output ZIP. Shares MPS cache with the outer build to avoid redundant downloads.
- Updates foojay-resolver-convention from 0.8.0 to 1.0.0 to fix Gradle 9.x compatibility (`JvmVendorSpec.IBM_SEMERU` removal).

Increases mps-gradle-plugin test count from 1 to 8.

## Test plan
- [x] All 8 mps-gradle-plugin tests pass locally (`./gradlew :mps-gradle-plugin:test`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)